### PR TITLE
Add a config for GitHub Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: /
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 3
+  versioning-strategy: lockfile-only
+  labels:
+  - dependencies


### PR DESCRIPTION
Dependabot has been acquired by GitHub a while back. And now they are migrating over from the dependabot-preview GitHub App to a built-in native GitHub Dependabot. It'll send pin updates the same way but you'll also be able to see the logs @ https://github.com/python-trio/snekomatic/network/updates.

This PR adds an initial config necessary for this migration.

The config and extra docs can be found here: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates.